### PR TITLE
Close stale issues/PRs

### DIFF
--- a/.github/workflows/close_stale.yml
+++ b/.github/workflows/close_stale.yml
@@ -1,0 +1,18 @@
+name: "Close stale issues/PR"
+on:
+  schedule:
+  - cron: "30 1 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/stale@v3
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'No activity recorded in this isssue for the past 30 days. This issue will be closed in 2 days.'
+        stale-pr-message: 'No activity recorded in this PR for the past 30 days. This PR will be closed in 2 days.'
+        close-issue-message: 'Closing stale issue.' 
+        close-pr-message: 'Closing stale PR'
+        days-before-stale: 30
+        days-before-close: 2


### PR DESCRIPTION
Added a workflow to close stale issues and PRs.
Issues/PRs with no activity for more than 30 days is marked stale and closed 2 days later.

Action runs every 24h